### PR TITLE
Refactor countdown to display weeks → millenniums

### DIFF
--- a/Timer countdown.py
+++ b/Timer countdown.py
@@ -8,8 +8,14 @@ for countdown in range(timer, 0, -1):
     seconds = countdown % 60
     minutes = int(countdown / 60) % 60
     hours = int(countdown / 3600) % 24
-    days = int(countdown / 86400) % 365
+    days = int(countdown / 86400) % 7
+    weeks = int(countdown / 604800) % 4
+    months = int(countdown / 2592000) % 12
+    years = int(countdown / 31536000) % 10
+    decades = int(countdown / 315360000) % 10
+    centuries = int(countdown / 3153600000) % 10
+    millenniums = int(countdown / 31536000000) % 10
     time.sleep(1)
-    print(f"{days:02}:{hours:02}:{minutes:02}:{seconds:02}")
+    print(f"{millenniums:02}:{centuries:02}:{decades:02}:{years:02}:{months:02}:{weeks:02}:{days:02}:{hours:02}:{minutes:02}:{seconds:02}")
 # after the countdown The program will print "Time's Up!"
 print("Time's Up!")


### PR DESCRIPTION
# **Refactor countdown to display weeks → millenniums**

### **Summary:**

- Extend the countdown display to include weeks, months, years, decades, centuries, and millenniums. The main change is in Timer countdown.py where additional unit calculations are added and the printed format becomes: millenniums:centuries:decades:years:months:weeks:days:hours:minutes:seconds

### **File changed:**

- Timer countdown.py

### **Behavior:**

- Computes each larger unit via integer division of the total seconds and prints all units zero-padded to two digits. Example output: 00:00:00:00:00:00:03:12:34:56

### **Notes / caveats:**

- Uses fixed-length approximations (month = 30 days, year = 365 days, etc.); does not account for leap years, variable month lengths, or time zones.
- Arithmetic is naive integer division/modulo; consider using datetime/relativedelta for calendar-accurate intervals.
- Very large timers may exceed two-digit display for some units; formatting may need adjustment.